### PR TITLE
Fix tests - PHP 5.3, DBAL < 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
     - 5.3
 
 env:
-    - DBAL_VERSION=2.1.*
     - DBAL_VERSION=2.2.*
     - DBAL_VERSION=2.3.*
     - DBAL_VERSION=2.4.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
     - DBAL_VERSION=2.1.*
     - DBAL_VERSION=2.2.*
     - DBAL_VERSION=2.3.*
+    - DBAL_VERSION=2.4.*
+    - DBAL_VERSION=2.5.*@dev
 
 before_script:
    - composer require doctrine/dbal:${DBAL_VERSION}

--- a/src/Doctrine/DBAL/Schema/Builder.php
+++ b/src/Doctrine/DBAL/Schema/Builder.php
@@ -151,7 +151,11 @@ class Builder
         // Where the foreign columns are not specified they are retrieved from
         // the foreign tables primary key definition.
         if (is_null($foreignColumns)) {
-            $foreignColumns = $foreignTable->getPrimaryKeyColumns();
+            if (method_exists($foreignTable, 'getPrimaryKeyColumns')) {
+                $foreignColumns = $foreignTable->getPrimaryKeyColumns();
+            } else {
+                $foreignColumns = $foreignTable->getPrimaryKey()->getColumns();
+            }
         }
 
         // Where the foreign key exists, it should be removed for recreation

--- a/test/Doctrine/DBAL/Schema/BuilderTest.php
+++ b/test/Doctrine/DBAL/Schema/BuilderTest.php
@@ -156,7 +156,7 @@ class BuilderTest extends TestCase
         $bar = new Table('bar', array(
             new Column('id', Type::getType('integer')),
         ));
-        $bar->setPrimaryKey(['id']);
+        $bar->setPrimaryKey(array('id'));
 
         $foo = new Table('foo', array(
             new Column('bar_id', Type::getType('integer')),
@@ -165,13 +165,13 @@ class BuilderTest extends TestCase
         $schema = new Schema(array($foo, $bar));
         $builder = new Builder($schema);
 
-        $builder->defineNamedForeignKey('FK_Foo_bar', 'foo', ['bar_id'], 'bar');
+        $builder->defineNamedForeignKey('FK_Foo_bar', 'foo', array('bar_id'), 'bar');
 
         $fk = $foo->getForeignKey('FK_Foo_bar');
         $this->assertEquals('foo', $fk->getLocalTableName(), 'foreign key should be on `foo`');
-        $this->assertEquals(['bar_id'], $fk->getLocalColumns(), 'foreign key have local column `bar_id` as the reference');
+        $this->assertEquals(array('bar_id'), $fk->getLocalColumns(), 'foreign key have local column `bar_id` as the reference');
         $this->assertEquals('bar', $fk->getForeignTableName(), 'foreign key should reference `bar`');
-        $this->assertEquals(['id'], $fk->getForeignColumns(), 'foreign key should reference the `id` column');
+        $this->assertEquals(array('id'), $fk->getForeignColumns(), 'foreign key should reference the `id` column');
     }
 
     public function testDefineNamedForeignKeyAsOverride()
@@ -179,21 +179,21 @@ class BuilderTest extends TestCase
         $bar = new Table('bar', array(
             new Column('id', Type::getType('integer')),
         ));
-        $bar->setPrimaryKey(['id']);
+        $bar->setPrimaryKey(array('id'));
 
         $foo = new Table('foo', array(
             new Column('bar_id', Type::getType('integer')),
         ));
-        $oldKey = $foo->addNamedForeignKeyConstraint('FK_Foo_bar', 'bar', ['bar_id'], ['baz']);
+        $oldKey = $foo->addNamedForeignKeyConstraint('FK_Foo_bar', 'bar', array('bar_id'), array('baz'));
 
         $schema = new Schema(array($foo, $bar));
         $builder = new Builder($schema);
 
-        $builder->defineNamedForeignKey('FK_Foo_bar', $foo, ['bar_id'], $bar, ['id']);
+        $builder->defineNamedForeignKey('FK_Foo_bar', $foo, array('bar_id'), $bar, array('id'));
 
         $fk = $foo->getForeignKey('FK_Foo_bar');
         $this->assertCount(1, $foo->getForeignKeys(), 'foreign key should have replaced exising key');
         $this->assertEquals('bar', $fk->getForeignTableName(), 'foreign key should reference the `bar` table');
-        $this->assertEquals(['id'], $fk->getForeignColumns(), 'foreign key should reference the `id` column');
+        $this->assertEquals(array('id'), $fk->getForeignColumns(), 'foreign key should reference the `id` column');
     }
 }


### PR DESCRIPTION
- Swapped `[]` for `array()` in tests to make tests pass on 5.3 (don't use it myself).
- Added an alternative for `getPrimaryKeyColumns()` on DBAL < 2.3
- Added DBAL v2.4 and v2.5 for Travis testing
- Removed DBAL v2.1 as it doesn't support removing foreign keys
